### PR TITLE
add local time api route

### DIFF
--- a/lib/expressapp.js
+++ b/lib/expressapp.js
@@ -642,6 +642,13 @@ ExpressApp.prototype.start = function(opts, cb) {
     res.end();
   });
 
+  router.get('/v1/time/', function(req, res) {
+      res.json({
+          localTime: Math.floor(new Date() / 1000),
+      });
+      res.end();
+  });
+
   router.post('/v1/login/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
       server.login({}, function(err, session) {

--- a/lib/expressapp.js
+++ b/lib/expressapp.js
@@ -642,9 +642,10 @@ ExpressApp.prototype.start = function(opts, cb) {
     res.end();
   });
 
-  router.get('/v1/time/', function(req, res) {
+  router.get('/v1/status/', function(req, res) {
       res.json({
-          localTime: Math.floor(new Date() / 1000),
+          status: "OK",
+          timestamp: Math.floor(new Date() / 1000),
       });
       res.end();
   });


### PR DESCRIPTION
This API route will be used to enforce copay's 5 minute wallet lockout which occurs after 3 unsuccessful attempts at entering their PIN.